### PR TITLE
fix link to screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Interfaces between `napari` and the `pymeshlab` library to allow import, export,
 This is a WIP and feature requests are welcome. Please check [PyMeshLab](https://pymeshlab.readthedocs.io/en/latest/)
 for possible features.
 
-![img.png](docs/screenshot.png)
+![img.png](https://github.com/zacsimile/napari-pymeshlab/raw/main/docs/screenshot.png)
 
 ## Feature list
 


### PR DESCRIPTION
Hi @zacsimile ,

this should fix the broken link to the image on the napari hub. It's always good if the screenshots are visible ;-)
Also for fixing this, a deployment to pypi is necessary.

Thanks!
Robert